### PR TITLE
Fix typo in stablediffusion.js file

### DIFF
--- a/pages/api/stablediffusion.js
+++ b/pages/api/stablediffusion.js
@@ -32,7 +32,7 @@ const handler = async (req, res) => {
 
 
     console.log(output)
-    res.staus(200).json(output)
+    res.status(200).json(output)
     //res.status(200).json([
      //   'https://replicate.delivery/pbxt/neqGIe66cYuPOUPM0JqokMfqsX9CRYgvkycUxyqlCKUjwJchA/out-0.png'
     //  ]


### PR DESCRIPTION
This pull request fixes a typo in the pages/api/stablediffusion.js file. On line 35, the response object was incorrectly spelled as res.staus instead of res.status. This could cause errors or unexpected behavior when calling the API endpoint. The typo has been corrected and the file has been tested locally.
